### PR TITLE
Updated FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -15,7 +15,7 @@ Most chains publish their type bundles as an npm package. One of the best places
 
 Note that the type bundle format for typegen is slightly different from `OverrideBundleDefinition` of `polkadot.js`. The structure is as follows, all the fields are optional.
 
-```json
+```javascript
 {
   types: {}, // top-level type definitions, as `.types` option of `ApiPromise`
   typesAlias: {}, // top-level type alieases, as `.typesAlias` option of `ApiPromise`


### PR DESCRIPTION
Fixed the first code section, as `json` was showing the whole block as an error, since it does not comply with JSON syntax