### PR TITLE
Added bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - specify the version of the core packages (@subsquid/cli, @subsquid/substrate-processor, ...)
+ - node.js version
+ - npm version
+ - OS version
+ - Reproducible example or a repo link
+
+**Applicable to decoding issues:**
+ - chain name
+ - typesBundle (if it's not built-in)
+optional:
+ - block
+ - extrinsic
+ - call
+ - event
+ - spec version
+ - endpoint
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Adding a template to suggest people what and how to report when creating an issue.

<img width="1376" alt="Screen Shot 2022-09-01 at 18 45 27" src="https://user-images.githubusercontent.com/6950554/187968574-aa7ed046-10e6-4c4a-9d37-b708070504d9.png">

And this is how it shows up when selected:

<img width="1118" alt="Screen Shot 2022-09-01 at 18 45 37" src="https://user-images.githubusercontent.com/6950554/187968688-95b18e5e-be72-4348-afc0-7429c4d29ada.png">
