### PR TITLE
Mute npm run logs in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ COPY --from=deps /squid/package.json .
 COPY --from=deps /squid/package-lock.json .
 COPY --from=deps /squid/node_modules node_modules
 COPY --from=builder /squid/lib lib
+RUN echo -e "loglevel=silent\nupdate-notifier=false" > /squid/.npmrc
 ADD db db
 ADD assets assets
 ADD schema.graphql .


### PR DESCRIPTION
Before
```
docker run --rm -it node_squid npm run query-node:start

> query-node:start
> squid-graphql-server --subscriptions

10:37:25 INFO  sqd:graphql-server listening on port 4000
^Cnpm notice
npm notice New minor version of npm available! 8.15.0 -> 8.19.2
npm notice Changelog: https://github.com/npm/cli/releases/tag/v8.19.2
npm notice Run npm install -g npm@8.19.2 to update!
npm notice
npm ERR! path /squid
npm ERR! command failed
npm ERR! signal SIGINT
npm ERR! command sh /tmp/query-nodestart-ec59bf6e.sh

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2022-10-10T10_37_25_190Z-debug-0.log
```

After
```
docker run --rm -it node_squid npm run query-node:start
10:43:37 INFO  sqd:graphql-server listening on port 4000
^C%
```